### PR TITLE
Hides End of Accordion elements except when editing

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -1,0 +1,7 @@
+.collapse-end {
+  display: none;
+}
+
+.mode-interact .collapse-end {
+  display: block;
+}

--- a/widget.json
+++ b/widget.json
@@ -21,6 +21,9 @@
     "dependencies": [
       "jquery",
       "bootstrap"
+    ],
+    "assets": [
+      "css/build.css"
     ]
   }
 }


### PR DESCRIPTION
The **End of Accordion** elements are refactored in real time when the page loads. However, they are temporarily displayed before the page finishes loading. This PR hides the **End of Accordion** elements -- unless the user is viewing the page in edit mode, which requires the **End of Accordion** element to be visible.

Ref. https://github.com/Fliplet/fliplet-studio/issues/2719